### PR TITLE
Add audio playback during calibration

### DIFF
--- a/AudioPaths.js
+++ b/AudioPaths.js
@@ -1,4 +1,4 @@
 export const audioPaths = {
-  circle: '',
-  square: ''
+  star: 'audio/star.mp3',
+  square: 'audio/square.mp3'
 };

--- a/CalibrateManager.js
+++ b/CalibrateManager.js
@@ -12,7 +12,14 @@ if (!(shapeImgElement instanceof HTMLImageElement)) {
     throw new Error('Expected #calibrateShape-image to be an HTMLImageElement');
 }
 
-const shapeImg = shapeImgElement; 
+const shapeImg = shapeImgElement;
+const audio = new Audio();
+
+function playShapeAudio(shape) {
+    if (!shape || !shape.audioPath) return;
+    audio.src = shape.audioPath;
+    audio.play();
+}
 
 (() => {
     setElementActive(calibrateContainer, false);
@@ -43,6 +50,7 @@ nextShapeBtn.onclick = () => {
     shapeImg.src = currentDisplayedShape.imagePath;
     shapeImg.alt = currentDisplayedShape.name;
     shapeNameElement.textContent = currentDisplayedShape.name; // Show name
+    playShapeAudio(currentDisplayedShape);
 };
 
 
@@ -61,5 +69,6 @@ function SetRandomShape() {
     shapeImg.src = currentDisplayedShape.imagePath;
     shapeImg.alt = currentDisplayedShape.name;
     shapeNameElement.textContent = currentDisplayedShape.name; // Show name
+    playShapeAudio(currentDisplayedShape);
 }
 

--- a/ShapeManager.js
+++ b/ShapeManager.js
@@ -3,7 +3,7 @@ import { shapePaths } from './AssetsPath.js';
 import { audioPaths } from './AudioPaths.js';
 
 export const availableShapes = [
-  new Shape('Star', shapePaths.black_star, ''),
+  new Shape('Star', shapePaths.black_star, audioPaths.star),
   new Shape('Square', shapePaths.black_square, audioPaths.square)
 ];
 


### PR DESCRIPTION
## Summary
- hook up audio file paths for star and square
- load audio resources in ShapeManager
- play audio clips whenever calibration shows a shape

## Testing
- `git status --short`