### PR TITLE
Implement success/error audio cues

### DIFF
--- a/AudioPaths.js
+++ b/AudioPaths.js
@@ -2,5 +2,7 @@ export const audioPaths = {
   star: 'audio/star.mp3',
   square: 'audio/square.mp3',
   new_shape_displayed: 'audio/new_shape_displayed.mp3',
-  swipe_rule: 'audio/swipe_rule.mp3'
+  swipe_rule: 'audio/swipe_rule.mp3',
+  guess_success: 'audio/guess_success.mp3',
+  guess_error: 'audio/guess_error.mp3'
 };

--- a/main.js
+++ b/main.js
@@ -18,6 +18,8 @@ const roundCounter = document.getElementById('round-counter');
 const roundBoard = document.getElementById('round-board');
 const newShapeAudio = new Audio(audioPaths.new_shape_displayed);
 const swipeRuleAudio = new Audio(audioPaths.swipe_rule);
+const guessSuccessAudio = new Audio(audioPaths.guess_success);
+const guessErrorAudio = new Audio(audioPaths.guess_error);
 let isFirstShape = true;
 
 let shapeManager; 
@@ -44,21 +46,29 @@ function handleShapeClick(buttonId) {
 
   gameManager.setCurrentRoundShape(shapeManager.currentShape);
 
-  if (buttonId === shapeManager.currentShape.name) {
+  const isCorrect = buttonId === shapeManager.currentShape.name;
+
+  if (isCorrect) {
     gameManager.increasePoint();
     gameManager.setCurrentRoundSuccess(true);
-    gameManager.increaseRound();
-  } else {
-    gameManager.increaseRound();
   }
+  gameManager.increaseRound();
+
+  const audio = isCorrect ? guessSuccessAudio : guessErrorAudio;
+  audio.currentTime = 0;
+  audio.play();
 
   console.log('Succeed count ' + gameManager.succeededCount)
   if (gameManager.currentRound >= gameManager.roundCount) {
-    setElementActive(gameContainer, false);
-    displayResult(gameManager.succeededCount, gameManager.roundCount);
+    setTimeout(() => {
+      setElementActive(gameContainer, false);
+      displayResult(gameManager.succeededCount, gameManager.roundCount);
+    }, 500);
   } else {
     RefreshRoundCount();
-    DisplayRandomShape();
+    setTimeout(() => {
+      DisplayRandomShape();
+    }, 500);
   }
 }
 


### PR DESCRIPTION
## Summary
- add success and error audio paths
- play success/error sounds after guessing
- delay next shape until audio plays

## Testing
- `node -e "console.log('no tests')"`