### PR TITLE
Implement postMessage result reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Mindsight Game
+
+This repository contains a simple shape guessing game used for calibration and testing.
+
+## Message API
+
+When a session ends, `main.js` posts a message to the embedding window with the user's results. Listeners can capture this event via `window.addEventListener('message', ...)`.
+
+```javascript
+{
+  type: 'GAME_RESULT',
+  payload: {
+    date: '<ISO date string>',
+    results: [ /* per–round result objects */ ]
+  }
+}
+```
+
+The `results` array mirrors the round results stored by the game and includes the shape information and whether the user answered correctly for each round.

--- a/main.js
+++ b/main.js
@@ -50,6 +50,7 @@ function displayResult(score, totalRound){
     setElementActive(resultContainer, true);
     resultText.textContent = score + "/" + totalRound;
     renderRoundBoard();
+    postGameResult(gameManager.roundResults);
 }
 
 function handleShapeClick(buttonId) {
@@ -189,6 +190,20 @@ function RestartGame() {
     setCalibrateContainerActive(false);
 
     roundBoard.innerHTML = ''; // clear board
+}
+
+// Post the result to the embedding parent. The message contains:
+//   {
+//     type: 'GAME_RESULT',
+//     payload: { date: ISOString, results: Array }
+//   }
+// Consumers can listen for this event to receive a session summary.
+function postGameResult(results) {
+    const payload = {
+        date: new Date().toISOString(),
+        results
+    };
+    window.parent.postMessage({ type: 'GAME_RESULT', payload }, '*');
 }
 
 


### PR DESCRIPTION
## Summary
- send game results to parent window via `window.parent.postMessage`
- expose `postGameResult` to format the payload
- update displayResult to send results
- document the posted message in a new README

## Testing
- `npm test` *(fails: package.json missing)*