### PR TITLE
Add fullscreen mode button

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <button id="nextShape-calibrate-button">Next</button>
   </div>
   <div id="switchCalibrateShape-container"></div>
+  <button id="start-calibrate-button" class="start-button">Start Game</button>
 </section>
 
     <button id="start-button" class="start-button">Start Game</button>
@@ -25,6 +26,7 @@
       <p id="round-counter"></p>
       <img id="shape-image" alt="Shape Image" />
       <div id="button-container"></div>
+      <button id="fullscreen-button" class="fullscreen-button">Fullscreen</button>
     </section>
 
     <section id="result-container" class="card hidden">

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ import { startCalibrating } from './CalibrateManager.js';
 import { SWIPE_THRESHOLD } from './constants.js';
 
 const startBtn = document.getElementById('start-button');
+const calibrateStartBtn = document.getElementById('start-calibrate-button');
 const gameContainer = document.getElementById('game-container');
 const resultContainer = document.getElementById('result-container');
 const resultText = document.getElementById('result-score');
@@ -16,6 +17,7 @@ const playAgainBtn = document.getElementById('playAgain-button');
 const endCalibrateBtn = document.getElementById('end-calibrate-button');
 const roundCounter = document.getElementById('round-counter');
 const roundBoard = document.getElementById('round-board');
+const fullscreenBtn = document.getElementById('fullscreen-button');
 const newShapeAudio = new Audio(audioPaths.new_shape_displayed);
 const swipeRuleAudio = new Audio(audioPaths.swipe_rule);
 const guessSuccessAudio = new Audio(audioPaths.guess_success);
@@ -176,9 +178,35 @@ function createButtonContainer() {
   return container;
 }
 
+function toggleFullscreen() {
+    if (!document.fullscreenElement) {
+        document.documentElement.requestFullscreen();
+    } else {
+        document.exitFullscreen();
+    }
+}
+
+function updateFullscreenButton() {
+    fullscreenBtn.textContent = document.fullscreenElement ? 'Exit Fullscreen' : 'Fullscreen';
+}
+
+fullscreenBtn.onclick = () => {
+    toggleFullscreen();
+};
+
+document.addEventListener('fullscreenchange', updateFullscreenButton);
+
+updateFullscreenButton();
+
 startBtn.onclick = () => {
   RestartGame();
 };
+
+if (calibrateStartBtn) {
+  calibrateStartBtn.onclick = () => {
+    RestartGame();
+  };
+}
 
 playAgainBtn.onclick = () => {
     RestartGame();

--- a/styles.css
+++ b/styles.css
@@ -80,6 +80,18 @@ button:hover {
   flex-wrap: wrap;
 }
 
+#game-container {
+  position: relative;
+}
+
+.fullscreen-button {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  padding: 8px 16px;
+  font-size: 14px;
+}
+
 #round-board ul {
   list-style-type: none;
   padding-left: 0;


### PR DESCRIPTION
## Summary
- add fullscreen button in the game view
- style fullscreen button and position it
- implement fullscreen toggling logic in `main.js`
- move the start game button inside the calibrate section
- restore start button on home screen
- let calibration start button launch the game

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_684ed8ed947c8320b21d95e0238a8d6f