### PR TITLE
Add start button inside calibration

### DIFF
--- a/CalibrateManager.js
+++ b/CalibrateManager.js
@@ -4,6 +4,8 @@ const calibrateBtn = document.getElementById('calibrate-button');
 const calibrateContainer = document.getElementById('calibrate-container');
 const nextShapeBtn = document.getElementById('nextShape-calibrate-button');
 const shapeNameElement = document.getElementById('calibrateShape-name');
+const calibrateStartBtn = document.getElementById('calibrate-start-button');
+const startBtnOutside = document.getElementById('start-button');
 
 const shapeImgElement = document.getElementById('calibrateShape-image');
 
@@ -25,6 +27,7 @@ function playShapeAudio(shape) {
 (() => {
     setElementActive(calibrateContainer, false);
     setElementActive(nextShapeBtn, false);
+    setElementActive(calibrateStartBtn, false);
 })();
 
 export function setElementActive(container, active) {
@@ -61,6 +64,8 @@ export function startCalibrating() {
     setElementActive(calibrateContainer, true);
     setElementActive(nextShapeBtn, true);
     setCalibrateButtonActive(false);
+    setElementActive(calibrateStartBtn, true);
+    setElementActive(startBtnOutside, false);
     SetRandomShape();
 }
 

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <img id="calibrateShape-image" alt="Shape Image" />
     <p id="calibrateShape-name"></p>
     <button id="nextShape-calibrate-button">Next</button>
+    <button id="calibrate-start-button" class="start-button">Start Game</button>
   </div>
   <div id="switchCalibrateShape-container"></div>
 </section>

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ import { startCalibrating } from './CalibrateManager.js';
 import { SWIPE_THRESHOLD } from './constants.js';
 
 const startBtn = document.getElementById('start-button');
+const calibrateStartBtn = document.getElementById('calibrate-start-button');
 const gameContainer = document.getElementById('game-container');
 const resultContainer = document.getElementById('result-container');
 const resultText = document.getElementById('result-score');
@@ -180,6 +181,10 @@ startBtn.onclick = () => {
   RestartGame();
 };
 
+calibrateStartBtn.onclick = () => {
+    RestartGame();
+};
+
 playAgainBtn.onclick = () => {
     RestartGame();
 }
@@ -198,6 +203,7 @@ function RestartGame() {
     DisplayRandomShape();
     setElementActive(resultContainer, false);
     setElementActive(startBtn, false);
+    setElementActive(calibrateStartBtn, false);
     setElementActive(gameContainer, true);
 
     setCalibrateButtonActive(false);


### PR DESCRIPTION
## Summary
- add a dedicated Start Game button inside the calibration section
- hide the outside Start Game button when calibrating
- wire up the new button so it starts the game

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684ee4b5dfe08320a2b02c518baed1a4