### PR TITLE
Add i18n support for UI labels

### DIFF
--- a/CalibrateManager.js
+++ b/CalibrateManager.js
@@ -10,6 +10,7 @@ const calibrateStartBtn = document.getElementById('calibrate-start-button');
 const startBtnOutside = document.getElementById('start-button');
 
 const currentLang = LangHelper.getLangFromURL();
+LangHelper.applyUIText(currentLang);
 
 const shapeImgElement = document.getElementById('calibrateShape-image');
 

--- a/LangHelper.js
+++ b/LangHelper.js
@@ -6,7 +6,7 @@ export const translations = {
     play_again: 'Play Again',
     your_score: 'Your Score:',
     round_results: 'Round Results:',
-    round_of: (c, t) => `Round ${c} of ${t}`,
+    round_of: function(c, t) { return 'Round ' + c + ' of ' + t; }
   },
   es: {
     calibrate: 'Calibrar',
@@ -15,41 +15,42 @@ export const translations = {
     play_again: 'Jugar de Nuevo',
     your_score: 'Tu Puntuación:',
     round_results: 'Resultados de la Ronda:',
-    round_of: (c, t) => `Ronda ${c} de ${t}`,
+    round_of: function(c, t) { return 'Ronda ' + c + ' de ' + t; }
   }
 };
 
-export class LangHelper {
-  static getLangFromURL() {
-    const params = new URLSearchParams(window.location.search);
-    return params.get('lang') || 'en';
-  }
+export function LangHelper() {}
 
-  static getStrings(lang) {
-    return translations[lang] || translations.en;
-  }
+LangHelper.getLangFromURL = function() {
+  var params = new URLSearchParams(window.location.search);
+  return params.get('lang') || 'en';
+};
 
-  static applyUIText(lang) {
-    const t = this.getStrings(lang);
+LangHelper.getStrings = function(lang) {
+  return translations[lang] || translations.en;
+};
 
-    document.documentElement.lang = lang;
+LangHelper.applyUIText = function(lang) {
+  var t = LangHelper.getStrings(lang);
 
-    const mapping = {
-      'calibrate-button': t.calibrate,
-      'nextShape-calibrate-button': t.next,
-      'calibrate-start-button': t.start_game,
-      'start-button': t.start_game,
-      'end-calibrate-button': t.calibrate,
-      'playAgain-button': t.play_again
-    };
+  document.documentElement.lang = lang;
 
-    for (const [id, text] of Object.entries(mapping)) {
-      const el = document.getElementById(id);
-      if (el) el.textContent = text;
+  var mapping = {
+    'calibrate-button': t.calibrate,
+    'nextShape-calibrate-button': t.next,
+    'calibrate-start-button': t.start_game,
+    'start-button': t.start_game,
+    'end-calibrate-button': t.calibrate,
+    'playAgain-button': t.play_again
+  };
+
+  for (var id in mapping) {
+    if (mapping.hasOwnProperty(id)) {
+      var el = document.getElementById(id);
+      if (el) el.textContent = mapping[id];
     }
-
-    const scoreHeader = document.querySelector('#result-container h2');
-    if (scoreHeader) scoreHeader.textContent = t.your_score;
   }
-}
 
+  var scoreHeader = document.querySelector('#result-container h2');
+  if (scoreHeader) scoreHeader.textContent = t.your_score;
+};

--- a/LangHelper.js
+++ b/LangHelper.js
@@ -1,10 +1,55 @@
+export const translations = {
+  en: {
+    calibrate: 'Calibrate',
+    start_game: 'Start Game',
+    next: 'Next',
+    play_again: 'Play Again',
+    your_score: 'Your Score:',
+    round_results: 'Round Results:',
+    round_of: (c, t) => `Round ${c} of ${t}`,
+  },
+  es: {
+    calibrate: 'Calibrar',
+    start_game: 'Iniciar Juego',
+    next: 'Siguiente',
+    play_again: 'Jugar de Nuevo',
+    your_score: 'Tu Puntuación:',
+    round_results: 'Resultados de la Ronda:',
+    round_of: (c, t) => `Ronda ${c} de ${t}`,
+  }
+};
+
 export class LangHelper {
   static getLangFromURL() {
     const params = new URLSearchParams(window.location.search);
-    return params.get('lang') || 'en'; // default to 'en' if missing
+    return params.get('lang') || 'en';
+  }
+
+  static getStrings(lang) {
+    return translations[lang] || translations.en;
+  }
+
+  static applyUIText(lang) {
+    const t = this.getStrings(lang);
+
+    document.documentElement.lang = lang;
+
+    const mapping = {
+      'calibrate-button': t.calibrate,
+      'nextShape-calibrate-button': t.next,
+      'calibrate-start-button': t.start_game,
+      'start-button': t.start_game,
+      'end-calibrate-button': t.calibrate,
+      'playAgain-button': t.play_again
+    };
+
+    for (const [id, text] of Object.entries(mapping)) {
+      const el = document.getElementById(id);
+      if (el) el.textContent = text;
+    }
+
+    const scoreHeader = document.querySelector('#result-container h2');
+    if (scoreHeader) scoreHeader.textContent = t.your_score;
   }
 }
 
-// Usage
-const currentLang = LangHelper.getLangFromURL();
-console.log("Current language:", currentLang);

--- a/main.js
+++ b/main.js
@@ -31,10 +31,13 @@ let shapeManager;
 let gameManager;
 
 let currentLang;
+let langStrings;
 
 (() => {
     currentLang = LangHelper.getLangFromURL();
     console.log("Lang: " + currentLang);
+    langStrings = LangHelper.getStrings(currentLang);
+    LangHelper.applyUIText(currentLang);
     const audioPaths = getAudioPaths(currentLang);
     newShapeAudio = new Audio(audioPaths.new_shape_displayed);
     swipeRuleAudio = new Audio(audioPaths.swipe_rule);
@@ -101,7 +104,7 @@ function handleShapeClick(buttonId) {
 }
 
 function renderRoundBoard() {
-    roundBoard.innerHTML = '<h3>Round Results:</h3>';
+    roundBoard.innerHTML = `<h3>${langStrings.round_results}</h3>`;
     const list = document.createElement('ul');
     gameManager.roundResults.forEach(({ success, shape }, index) => {
         const li = document.createElement('li');
@@ -177,7 +180,10 @@ function DisplayRandomShape() {
 }
 
 function RefreshRoundCount() {
-    roundCounter.textContent = `Round ${gameManager.currentRound + 1} of ${gameManager.roundCount}`;
+    roundCounter.textContent = langStrings.round_of(
+        gameManager.currentRound + 1,
+        gameManager.roundCount
+    );
 }
 
 function createButtonContainer() {

--- a/main.js
+++ b/main.js
@@ -35,7 +35,6 @@ let langStrings;
 
 (() => {
     currentLang = LangHelper.getLangFromURL();
-    console.log("Lang: " + currentLang);
     langStrings = LangHelper.getStrings(currentLang);
     LangHelper.applyUIText(currentLang);
     const audioPaths = getAudioPaths(currentLang);


### PR DESCRIPTION
## Summary
- implement translation strings and helper utilities
- apply translations when loading language
- update round board and counter to use translated text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6856e9c5b20c8320aab22f8bd613a13f