### PR TITLE
Add missing UI translations

### DIFF
--- a/CalibrateManager.js
+++ b/CalibrateManager.js
@@ -58,7 +58,7 @@ nextShapeBtn.onclick = () => {
 
     shapeImg.src = currentDisplayedShape.imagePath;
     shapeImg.alt = currentDisplayedShape.name;
-    shapeNameElement.textContent = currentDisplayedShape.name; // Show name
+    shapeNameElement.textContent = LangHelper.translateShapeName(currentDisplayedShape.name, currentLang); // Show localized name
     playShapeAudio(currentDisplayedShape);
 };
 
@@ -79,7 +79,7 @@ function SetRandomShape() {
     currentDisplayedShape = manager.getRandomShape();
     shapeImg.src = currentDisplayedShape.imagePath;
     shapeImg.alt = currentDisplayedShape.name;
-    shapeNameElement.textContent = currentDisplayedShape.name; // Show name
+    shapeNameElement.textContent = LangHelper.translateShapeName(currentDisplayedShape.name, currentLang); // Show localized name
     playShapeAudio(currentDisplayedShape);
 }
 

--- a/LangHelper.js
+++ b/LangHelper.js
@@ -4,6 +4,9 @@ export const translations = {
     start_game: 'Start Game',
     next: 'Next',
     play_again: 'Play Again',
+    star: 'Star',
+    square: 'Square',
+    shape_word: 'Shape',
     your_score: 'Your Score:',
     round_results: 'Round Results:',
     round_of: (c, t) => `Round ${c} of ${t}`,
@@ -13,6 +16,9 @@ export const translations = {
     start_game: 'Iniciar Juego',
     next: 'Siguiente',
     play_again: 'Jugar de Nuevo',
+    star: 'Estrella',
+    square: 'Cuadrado',
+    shape_word: 'Forma',
     your_score: 'Tu Puntuación:',
     round_results: 'Resultados de la Ronda:',
     round_of: (c, t) => `Ronda ${c} de ${t}`,
@@ -27,6 +33,14 @@ export class LangHelper {
 
   static getStrings(lang) {
     return translations[lang] || translations.en;
+  }
+
+  static translateShapeName(name, lang = 'en') {
+    const t = this.getStrings(lang);
+    const key = name.toLowerCase();
+    if (key.includes('star')) return t.star;
+    if (key.includes('square')) return t.square;
+    return name;
   }
 
   static applyUIText(lang) {

--- a/main.js
+++ b/main.js
@@ -119,14 +119,14 @@ function renderRoundBoard() {
         }
 
         img.src = shapePaths[shapeKey] || '';
-        img.alt = `Shape ${index + 1}`;
+        img.alt = `${langStrings.shape_word} ${index + 1}`;
         img.style.width = '30px';
         img.style.height = '30px';
         img.style.marginLeft = '20px';
         img.style.marginBottom = '20px';
         img.style.verticalAlign = 'middle';
 
-        li.textContent = `Shape ${index + 1}:`;
+        li.textContent = `${langStrings.shape_word} ${index + 1}:`;
         li.appendChild(img);
         list.appendChild(li);
     });
@@ -153,7 +153,7 @@ function setupGameUI() {
 
   shapeManager.availableShapes.forEach(s => {
     const btn = document.createElement('button');
-    btn.textContent = s.name;
+    btn.textContent = LangHelper.translateShapeName(s.name, currentLang);
     btn.id = s.name;
     btn.onclick = () => handleShapeClick(btn.id);
     buttonContainer.appendChild(btn);


### PR DESCRIPTION
## Summary
- localize shape names and result labels
- show localized names in calibration
- display localized shape names on game buttons

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_6856ed6cd3f48320a210bcd61ca19d04