### PR TITLE
Improve tutorial display and audio handling

### DIFF
--- a/AudioManager.js
+++ b/AudioManager.js
@@ -1,0 +1,27 @@
+export const AudioManager = (() => {
+    const audios = new Set();
+    function register(audio) {
+        if (audio && typeof audio.play === 'function') {
+            audios.add(audio);
+        }
+        return audio;
+    }
+    function play(audio) {
+        if (!audio) return;
+        audios.forEach(a => {
+            if (a !== audio) {
+                a.pause();
+                a.currentTime = 0;
+            }
+        });
+        audio.currentTime = 0;
+        audio.play();
+    }
+    function stopAll() {
+        audios.forEach(a => {
+            a.pause();
+            a.currentTime = 0;
+        });
+    }
+    return { register, play, stopAll };
+})();

--- a/CalibrateManager.js
+++ b/CalibrateManager.js
@@ -1,6 +1,7 @@
 import { ShapeManager } from './ShapeManager.js';
 import { SWIPE_THRESHOLD } from './constants.js';
 import { LangHelper } from './LangHelper.js';
+import { AudioManager } from './AudioManager.js';
 const calibrateBtn = document.getElementById('calibrate-button');
 const calibrateContainer = document.getElementById('calibrate-container');
 const calibrateContainerParent = document.getElementById('calibrate-container-parent');
@@ -21,12 +22,12 @@ if (!(shapeImgElement instanceof HTMLImageElement)) {
 }
 
 const shapeImg = shapeImgElement;
-const audio = new Audio();
+const audio = AudioManager.register(new Audio());
 
 function playShapeAudio(shape) {
     if (!shape || !shape.audioPath) return;
     audio.src = shape.audioPath;
-    audio.play();
+    AudioManager.play(audio);
 }
 
 (() => {

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ import { getAudioPaths } from './AudioPaths.js';
 import { setCalibrateButtonActive } from './CalibrateManager.js';
 import { setCalibrateContainerActive } from './CalibrateManager.js';
 import { startCalibrating } from './CalibrateManager.js';
+import { AudioManager } from './AudioManager.js';
 import { SWIPE_THRESHOLD } from './constants.js';
 import { LangHelper } from './LangHelper.js';
 
@@ -40,11 +41,11 @@ let langStrings;
     langStrings = LangHelper.getStrings(currentLang);
     LangHelper.applyUIText(currentLang);
     const audioPaths = getAudioPaths(currentLang);
-    newShapeAudio = new Audio(audioPaths.new_shape_displayed);
-    swipeRuleAudio = new Audio(audioPaths.swipe_rule);
-    guessSuccessAudio = new Audio(audioPaths.guess_success);
-    guessErrorAudio = new Audio(audioPaths.guess_error);
-    explainRulesAudio = new Audio(audioPaths.explain_rules);
+    newShapeAudio = AudioManager.register(new Audio(audioPaths.new_shape_displayed));
+    swipeRuleAudio = AudioManager.register(new Audio(audioPaths.swipe_rule));
+    guessSuccessAudio = AudioManager.register(new Audio(audioPaths.guess_success));
+    guessErrorAudio = AudioManager.register(new Audio(audioPaths.guess_error));
+    explainRulesAudio = AudioManager.register(new Audio(audioPaths.explain_rules));
 
     shapeManager = new ShapeManager('shape-text', 'shape-image', currentLang);
     gameManager = new GameManager();
@@ -92,8 +93,7 @@ function handleShapeClick(buttonId) {
   gameManager.increaseRound();
 
   const audio = isCorrect ? guessSuccessAudio : guessErrorAudio;
-  audio.currentTime = 0;
-  audio.play();
+  AudioManager.play(audio);
 
   if (gameManager.currentRound >= gameManager.roundCount) {
     setTimeout(() => {
@@ -172,8 +172,7 @@ function DisplayRandomShape() {
         shapeImg.src = shapeManager.currentShape.imagePath;
     }
     if (isFirstShape) {
-        swipeRuleAudio.currentTime = 0;
-        swipeRuleAudio.play();
+        AudioManager.play(swipeRuleAudio);
         isFirstShape = false;
     }
 
@@ -199,10 +198,10 @@ function showTutorial() {
   setElementActive(startBtn, false);
   setElementActive(calibrateStartBtn, false);
   setCalibrateContainerActive(false);
+  setCalibrateButtonActive(false);
   setElementActive(tutorialContainer, true);
 
-  explainRulesAudio.currentTime = 0;
-  explainRulesAudio.play();
+  AudioManager.play(explainRulesAudio);
 
   const startGame = (e) => {
     if (e.type === 'keydown' && e.code !== 'Space') return;

--- a/styles.css
+++ b/styles.css
@@ -42,9 +42,13 @@ html, body {
   align-items: center;
 }
 
-#shape-image,
-#calibrateShape-image {
+#shape-image {
   max-width: 200px;
+  margin-bottom: 20px;
+}
+
+#calibrateShape-image {
+  max-width: 220px;
   margin-bottom: 20px;
 }
 


### PR DESCRIPTION
## Summary
- hide calibrate button while tutorial image is showing
- add AudioManager helper to stop other sounds when one plays
- use AudioManager for game and calibration audio
- tweak calibrate image size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68780c0a08788320aa9c31793dae5387