### PR TITLE
Play completion audio when showing results

### DIFF
--- a/AudioPaths.js
+++ b/AudioPaths.js
@@ -4,7 +4,8 @@ export const audioFileNames = {
   swipe_rule: 'swipe_rule.mp3',
   explain_rules: 'explain_rules.mp3',
   guess_success: 'guess_success.mp3',
-  guess_error: 'guess_error.mp3'
+  guess_error: 'guess_error.mp3',
+  session_completed: 'session_completed.mp3'
 };
 
 export function getAudioPaths(lang = 'en') {

--- a/main.js
+++ b/main.js
@@ -27,6 +27,7 @@ let swipeRuleAudio;
 let guessSuccessAudio;
 let guessErrorAudio;
 let explainRulesAudio;
+let sessionCompletedAudio;
 let isFirstShape = true;
 let isAwaitingShape = false;
 
@@ -46,6 +47,7 @@ let langStrings;
     guessSuccessAudio = AudioManager.register(new Audio(audioPaths.guess_success));
     guessErrorAudio = AudioManager.register(new Audio(audioPaths.guess_error));
     explainRulesAudio = AudioManager.register(new Audio(audioPaths.explain_rules));
+    sessionCompletedAudio = AudioManager.register(new Audio(audioPaths.session_completed));
 
     shapeManager = new ShapeManager('shape-text', 'shape-image', currentLang);
     gameManager = new GameManager();
@@ -71,6 +73,7 @@ function setButtonsEnabled(enabled) {
 function displayResult(score, totalRound){
     setElementActive(resultContainer, true);
     resultText.textContent = score + "/" + totalRound;
+    AudioManager.play(sessionCompletedAudio);
     renderRoundBoard();
     saveTrainingResult();
 }


### PR DESCRIPTION
## Summary
- map new audio file `session_completed.mp3`
- register completion audio on startup
- play completion audio when displaying results

## Testing
- `# No tests to run`

------
https://chatgpt.com/codex/tasks/task_b_687811f53e648320b1f591472d911ca0