### PR TITLE
Add calibration tutorial with audio

### DIFF
--- a/AudioPaths.js
+++ b/AudioPaths.js
@@ -3,6 +3,7 @@ export const audioFileNames = {
   square: 'square.mp3',
   swipe_rule: 'swipe_rule.mp3',
   explain_rules: 'explain_rules.mp3',
+  calibrate_rules: 'calibrate_rules.mp3',
   guess_success: 'guess_success.mp3',
   guess_error: 'guess_error.mp3',
   session_completed: 'session_completed.mp3'

--- a/CalibrateManager.js
+++ b/CalibrateManager.js
@@ -2,6 +2,7 @@ import { ShapeManager } from './ShapeManager.js';
 import { SWIPE_THRESHOLD } from './constants.js';
 import { LangHelper } from './LangHelper.js';
 import { AudioManager } from './AudioManager.js';
+import { getAudioPaths } from './AudioPaths.js';
 const calibrateBtn = document.getElementById('calibrate-button');
 const calibrateContainer = document.getElementById('calibrate-container');
 const calibrateContainerParent = document.getElementById('calibrate-container-parent');
@@ -23,6 +24,7 @@ if (!(shapeImgElement instanceof HTMLImageElement)) {
 
 const shapeImg = shapeImgElement;
 const audio = AudioManager.register(new Audio());
+let calibrateRulesAudio;
 
 function playShapeAudio(shape) {
     if (!shape || !shape.audioPath) return;
@@ -34,6 +36,8 @@ function playShapeAudio(shape) {
     setElementActive(calibrateContainerParent, false);
     setElementActive(nextShapeBtn, false);
     setElementActive(calibrateStartBtn, false);
+    const audioPaths = getAudioPaths(currentLang);
+    calibrateRulesAudio = AudioManager.register(new Audio(audioPaths.calibrate_rules));
 })();
 
 export function setElementActive(container, active) {
@@ -67,12 +71,38 @@ nextShapeBtn.onclick = () => {
 calibrateBtn.onclick = startCalibrating;
 
 export function startCalibrating() {
-    setElementActive(calibrateContainerParent, true);
+    setCalibrateContainerActive(false);
+    showCalibrateTutorial();
+}
+
+function beginCalibrationSession() {
+    setCalibrateContainerActive(true);
     setElementActive(nextShapeBtn, true);
     setCalibrateButtonActive(false);
     setElementActive(calibrateStartBtn, true);
     setElementActive(startBtnOutside, false);
     SetRandomShape();
+}
+
+function showCalibrateTutorial() {
+    const tutorialContainer = document.getElementById('tutorial-container');
+    if (!tutorialContainer) return;
+    setCalibrateButtonActive(false);
+    setElementActive(startBtnOutside, false);
+    setElementActive(tutorialContainer, true);
+    tutorialContainer.style.display = 'flex';
+    AudioManager.play(calibrateRulesAudio);
+
+    const begin = (e) => {
+        if (e.type === 'keydown' && e.code !== 'Space') return;
+        document.removeEventListener('keydown', begin);
+        document.removeEventListener('touchend', begin);
+        setElementActive(tutorialContainer, false);
+        beginCalibrationSession();
+    };
+
+    document.addEventListener('keydown', begin);
+    document.addEventListener('touchend', begin);
 }
 
 function SetRandomShape() {

--- a/main.js
+++ b/main.js
@@ -233,7 +233,6 @@ playAgainBtn.onclick = () => {
 endCalibrateBtn.onclick = () => {
       setElementActive(gameContainerParent, false);
       setElementActive(resultContainer, false);
-      setCalibrateContainerActive(true);
       setElementActive(startBtn, true);
       startCalibrating();
 }


### PR DESCRIPTION
## Summary
- include new `calibrate_rules` audio path
- show tutorial overlay before calibration begins
- play `calibrate_rules` audio during calibration tutorial
- avoid showing calibrate container until tutorial is dismissed

## Testing
- `node --check AudioPaths.js`
- `node --check CalibrateManager.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_b_687ec572c4fc83209a3c094e6aa519c1