### PR TITLE
Adjust mobile layout of shape buttons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -130,6 +130,7 @@ button:hover {
     display: flex;
     flex-grow: 1;
     width: 100%;
+    gap: 4px;
   }
 
   #button-container button {

--- a/styles.css
+++ b/styles.css
@@ -125,3 +125,18 @@ button:hover {
 }
 
 
+@media (max-width: 768px) {
+  #button-container {
+    display: flex;
+    flex-grow: 1;
+    width: 100%;
+  }
+
+  #button-container button {
+    flex: 1;
+    margin: 0;
+    height: 100%;
+    border-radius: 0;
+  }
+}
+


### PR DESCRIPTION
## Summary
- make star and square buttons fill the remaining space on mobile devices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688179ab89808320a8110bbfdcce8d75