### PR TITLE
Request fullscreen when sessions start

### DIFF
--- a/CalibrateManager.js
+++ b/CalibrateManager.js
@@ -89,6 +89,7 @@ function beginCalibrationSession() {
 function showCalibrateTutorial() {
     const tutorialContainer = document.getElementById('tutorial-container');
     if (!tutorialContainer) return;
+    requestFullscreen();
     setCalibrateButtonActive(false);
     setElementActive(startBtnOutside, false);
     setElementActive(tutorialContainer, true);

--- a/CalibrateManager.js
+++ b/CalibrateManager.js
@@ -77,7 +77,6 @@ export function startCalibrating() {
 }
 
 function beginCalibrationSession() {
-    requestFullscreen();
     setCalibrateContainerActive(true);
     setElementActive(nextShapeBtn, true);
     setCalibrateButtonActive(false);

--- a/CalibrateManager.js
+++ b/CalibrateManager.js
@@ -3,6 +3,7 @@ import { SWIPE_THRESHOLD } from './constants.js';
 import { LangHelper } from './LangHelper.js';
 import { AudioManager } from './AudioManager.js';
 import { getAudioPaths } from './AudioPaths.js';
+import { requestFullscreen } from './FullScreenHelper.js';
 const calibrateBtn = document.getElementById('calibrate-button');
 const calibrateContainer = document.getElementById('calibrate-container');
 const calibrateContainerParent = document.getElementById('calibrate-container-parent');
@@ -76,6 +77,7 @@ export function startCalibrating() {
 }
 
 function beginCalibrationSession() {
+    requestFullscreen();
     setCalibrateContainerActive(true);
     setElementActive(nextShapeBtn, true);
     setCalibrateButtonActive(false);

--- a/FullScreenHelper.js
+++ b/FullScreenHelper.js
@@ -1,0 +1,11 @@
+export function requestFullscreen() {
+    const elem = document.documentElement;
+    if (document.fullscreenElement) return;
+    if (elem.requestFullscreen) {
+        elem.requestFullscreen();
+    } else if (elem.webkitRequestFullscreen) {
+        elem.webkitRequestFullscreen();
+    } else if (elem.msRequestFullscreen) {
+        elem.msRequestFullscreen();
+    }
+}

--- a/main.js
+++ b/main.js
@@ -197,6 +197,7 @@ function createButtonContainer() {
 }
 
 function showTutorial() {
+  requestFullscreen();
   setElementActive(resultContainer, false);
   setElementActive(startBtn, false);
   setElementActive(calibrateStartBtn, false);

--- a/main.js
+++ b/main.js
@@ -240,7 +240,6 @@ endCalibrateBtn.onclick = () => {
 }
 
 function RestartGame() {
-    requestFullscreen();
     gameManager.reset();
     DisplayRandomShape();
     setElementActive(resultContainer, false);

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ import { startCalibrating } from './CalibrateManager.js';
 import { AudioManager } from './AudioManager.js';
 import { SWIPE_THRESHOLD } from './constants.js';
 import { LangHelper } from './LangHelper.js';
+import { requestFullscreen } from './FullScreenHelper.js';
 
 
 const startBtn = document.getElementById('start-button');
@@ -238,6 +239,7 @@ endCalibrateBtn.onclick = () => {
 }
 
 function RestartGame() {
+    requestFullscreen();
     gameManager.reset();
     DisplayRandomShape();
     setElementActive(resultContainer, false);


### PR DESCRIPTION
## Summary
- add helper to request fullscreen mode
- make calibration and game sessions enter fullscreen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68817c62657883208ad64fb973db3a8b