### PR TITLE
Fix tutorial tap event

### DIFF
--- a/main.js
+++ b/main.js
@@ -210,6 +210,11 @@ function showTutorial() {
 
   const startGame = (e) => {
     if (e.type === 'keydown' && e.code !== 'Space') return;
+    // Prevent the touch event from triggering a subsequent click on
+    // the now-visible game UI elements
+    if (e.cancelable) {
+      e.preventDefault();
+    }
     document.removeEventListener('keydown', startGame);
     document.removeEventListener('touchend', startGame);
     setElementActive(tutorialContainer, false);


### PR DESCRIPTION
## Summary
- prevent tutorial dismissal tap from clicking underlying game elements

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_688185c16070832098bf9886bde58dd8