### PR TITLE
Improve fullscreen UI and sizing

### DIFF
--- a/CalibrateManager.js
+++ b/CalibrateManager.js
@@ -143,10 +143,20 @@ calibrateContainer.addEventListener('touchend', (e) => {
 }, false);
 
 // -- Keyboard support --
+let spaceHeld = false;
+
 document.addEventListener('keydown', (e) => {
     if (e.code !== 'Space') return;
     const containerVisible = getComputedStyle(calibrateContainerParent).display !== 'none';
     if (!containerVisible) return;
+    if (spaceHeld) return;
+    spaceHeld = true;
     nextShapeBtn.click();
+});
+
+document.addEventListener('keyup', (e) => {
+    if (e.code === 'Space') {
+        spaceHeld = false;
+    }
 });
 

--- a/FullScreenHelper.js
+++ b/FullScreenHelper.js
@@ -10,3 +10,14 @@ export function requestFullscreen() {
         elem['msRequestFullscreen'](); // IE11
     }
 }
+
+export function exitFullscreen() {
+    if (!document.fullscreenElement) return;
+    if (document.exitFullscreen) {
+        document.exitFullscreen();
+    } else if (document['webkitExitFullscreen']) {
+        document['webkitExitFullscreen']();
+    } else if (document['msExitFullscreen']) {
+        document['msExitFullscreen']();
+    }
+}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
   <main class="wrapper">
+    <button id="enter-fullscreen-button" class="exit-fullscreen">Fullscreen</button>
     <button id="exit-fullscreen-button" class="exit-fullscreen">Exit</button>
     <button id="calibrate-button" class="primary-button">Calibrate</button>
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
   <main class="wrapper">
+    <button id="exit-fullscreen-button" class="exit-fullscreen">Exit</button>
     <button id="calibrate-button" class="primary-button">Calibrate</button>
 
     <section id="calibrate-container-parent" >

--- a/main.js
+++ b/main.js
@@ -79,7 +79,11 @@ window.addEventListener('resize', updateFullscreenButtonVisibility);
 
 if (exitFullscreenBtn) {
     exitFullscreenBtn.onclick = () => {
-        exitFullscreen();
+        if (document.fullscreenElement) {
+            exitFullscreen();
+        } else if (isBrowserFullscreen()) {
+            alert('Press F11 to exit fullscreen.');
+        }
     };
 }
 

--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ import { startCalibrating } from './CalibrateManager.js';
 import { AudioManager } from './AudioManager.js';
 import { SWIPE_THRESHOLD } from './constants.js';
 import { LangHelper } from './LangHelper.js';
-import { requestFullscreen } from './FullScreenHelper.js';
+import { requestFullscreen, exitFullscreen } from './FullScreenHelper.js';
 
 
 const startBtn = document.getElementById('start-button');
@@ -23,6 +23,7 @@ const endCalibrateBtn = document.getElementById('end-calibrate-button');
 const roundCounter = document.getElementById('round-counter');
 const roundBoard = document.getElementById('round-board');
 const tutorialContainer = document.getElementById('tutorial-container');
+const exitFullscreenBtn = document.getElementById('exit-fullscreen-button');
 let newShapeAudio;
 let swipeRuleAudio;
 let guessSuccessAudio;
@@ -54,6 +55,25 @@ let langStrings;
     setupGameUI();
     setElementActive(gameContainerParent, false);
 })();
+
+function isMobile() {
+    return /Mobi|Android/i.test(navigator.userAgent);
+}
+
+document.addEventListener('fullscreenchange', () => {
+    const isFs = !!document.fullscreenElement;
+    if (isFs && !isMobile()) {
+        exitFullscreenBtn.style.display = 'block';
+    } else {
+        exitFullscreenBtn.style.display = 'none';
+    }
+});
+
+if (exitFullscreenBtn) {
+    exitFullscreenBtn.onclick = () => {
+        exitFullscreen();
+    };
+}
 
 
 function setElementActive(container, active) {

--- a/main.js
+++ b/main.js
@@ -24,6 +24,7 @@ const roundCounter = document.getElementById('round-counter');
 const roundBoard = document.getElementById('round-board');
 const tutorialContainer = document.getElementById('tutorial-container');
 const exitFullscreenBtn = document.getElementById('exit-fullscreen-button');
+const enterFullscreenBtn = document.getElementById('enter-fullscreen-button');
 let newShapeAudio;
 let swipeRuleAudio;
 let guessSuccessAudio;
@@ -67,10 +68,13 @@ function isBrowserFullscreen() {
 function updateFullscreenButtonVisibility() {
     const inDomFullscreen = !!document.fullscreenElement;
     const inBrowserFullscreen = isBrowserFullscreen();
-    if ((inDomFullscreen || inBrowserFullscreen) && !isMobile()) {
-        exitFullscreenBtn.style.display = 'block';
-    } else {
-        exitFullscreenBtn.style.display = 'none';
+    const showExit = (inDomFullscreen || inBrowserFullscreen) && !isMobile();
+    const showEnter = !showExit && !isMobile();
+    if (exitFullscreenBtn) {
+        exitFullscreenBtn.style.display = showExit ? 'block' : 'none';
+    }
+    if (enterFullscreenBtn) {
+        enterFullscreenBtn.style.display = showEnter ? 'block' : 'none';
     }
 }
 
@@ -84,6 +88,12 @@ if (exitFullscreenBtn) {
         } else if (isBrowserFullscreen()) {
             alert('Press F11 to exit fullscreen.');
         }
+    };
+}
+
+if (enterFullscreenBtn) {
+    enterFullscreenBtn.onclick = () => {
+        requestFullscreen();
     };
 }
 

--- a/main.js
+++ b/main.js
@@ -60,20 +60,31 @@ function isMobile() {
     return /Mobi|Android/i.test(navigator.userAgent);
 }
 
-document.addEventListener('fullscreenchange', () => {
-    const isFs = !!document.fullscreenElement;
-    if (isFs && !isMobile()) {
+function isBrowserFullscreen() {
+    return window.innerHeight === screen.height && window.innerWidth === screen.width;
+}
+
+function updateFullscreenButtonVisibility() {
+    const inDomFullscreen = !!document.fullscreenElement;
+    const inBrowserFullscreen = isBrowserFullscreen();
+    if ((inDomFullscreen || inBrowserFullscreen) && !isMobile()) {
         exitFullscreenBtn.style.display = 'block';
     } else {
         exitFullscreenBtn.style.display = 'none';
     }
-});
+}
+
+document.addEventListener('fullscreenchange', updateFullscreenButtonVisibility);
+window.addEventListener('resize', updateFullscreenButtonVisibility);
 
 if (exitFullscreenBtn) {
     exitFullscreenBtn.onclick = () => {
         exitFullscreen();
     };
 }
+
+// Initialize button visibility on load
+updateFullscreenButtonVisibility();
 
 
 function setElementActive(container, active) {

--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,7 @@ html, body {
   flex-direction: column;
   align-items: center;
   justify-content: flex-start; /* Align content to top */
+  position: relative;
 }
 
 
@@ -74,6 +75,14 @@ button:hover {
   background-color: #2980b9;
 }
 
+#exit-fullscreen-button {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  display: none;
+  z-index: 1000;
+}
+
 .swiping {
   background-color: #f1c40f;
 }
@@ -118,6 +127,10 @@ button:hover {
   align-items: center;
 }
 
+#tutorial-container {
+  justify-content: center;
+}
+
 #tutorial-image {
   width: 90%;
   max-width: 600px;
@@ -138,6 +151,23 @@ button:hover {
     margin: 0;
     height: 100%;
     border-radius: 0;
+  }
+}
+
+@media (min-width: 768px) {
+  #game-container,
+  #calibrate-container,
+  #tutorial-container {
+    justify-content: center;
+  }
+
+  #shape-image,
+  #calibrateShape-image {
+    max-width: 40vh;
+  }
+
+  #tutorial-image {
+    width: 80%;
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -175,7 +175,7 @@ button:hover {
   }
 
   #tutorial-image {
-    width: 80%;
+    width: 100%;
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -83,6 +83,14 @@ button:hover {
   z-index: 1000;
 }
 
+#enter-fullscreen-button {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  display: none;
+  z-index: 1000;
+}
+
 .swiping {
   background-color: #f1c40f;
 }


### PR DESCRIPTION
## Summary
- center tutorial image
- make shapes larger on desktop
- add exit fullscreen button on desktop
- support exiting fullscreen via helper

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_6882a50438408320811c1ca6ba983567