### PR TITLE
Replace fullscreen button text with icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,22 @@
 </head>
 <body>
   <main class="wrapper">
-    <button id="enter-fullscreen-button" class="exit-fullscreen">Fullscreen</button>
-    <button id="exit-fullscreen-button" class="exit-fullscreen">Exit</button>
+    <button id="enter-fullscreen-button" class="exit-fullscreen" aria-label="Enter Fullscreen">
+      <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="8 3 3 3 3 8" />
+        <polyline points="16 3 21 3 21 8" />
+        <polyline points="21 16 21 21 16 21" />
+        <polyline points="3 16 3 21 8 21" />
+      </svg>
+    </button>
+    <button id="exit-fullscreen-button" class="exit-fullscreen" aria-label="Exit Fullscreen">
+      <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="9 3 9 9 3 9" />
+        <polyline points="15 3 15 9 21 9" />
+        <polyline points="21 15 15 15 15 21" />
+        <polyline points="3 15 9 15 9 21" />
+      </svg>
+    </button>
     <button id="calibrate-button" class="primary-button">Calibrate</button>
 
     <section id="calibrate-container-parent" >


### PR DESCRIPTION
## Summary
- swap text on fullscreen toggle buttons for inline SVG icons

## Testing
- `npx --version`
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6882b059c97c8320b6a4ebeeed8b9791