### PR TITLE
Fix fullscreen and centering on mobile

### DIFF
--- a/main.js
+++ b/main.js
@@ -68,8 +68,8 @@ function isBrowserFullscreen() {
 function updateFullscreenButtonVisibility() {
     const inDomFullscreen = !!document.fullscreenElement;
     const inBrowserFullscreen = isBrowserFullscreen();
-    const showExit = (inDomFullscreen || inBrowserFullscreen) && !isMobile();
-    const showEnter = !showExit && !isMobile();
+    const showExit = inDomFullscreen || inBrowserFullscreen;
+    const showEnter = !showExit;
     if (exitFullscreenBtn) {
         exitFullscreenBtn.style.display = showExit ? 'block' : 'none';
     }

--- a/styles.css
+++ b/styles.css
@@ -160,6 +160,11 @@ button:hover {
     height: 100%;
     border-radius: 0;
   }
+
+  #game-container,
+  #calibrate-container {
+    justify-content: center;
+  }
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- always show enter/exit fullscreen buttons, even on mobile
- center game shapes on mobile to match desktop behavior

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6882b8a297a88320bd2bb45da39cc939