### PR TITLE
Fix mobile counter and tap handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -310,18 +310,13 @@ function RestartGame() {
 }
 
 
-// -- Mobile swipe support --
+// -- Mobile tap/swipe handling --
 let touchStartX = 0;
 let touchEndX = 0;
 
-function handleSwipeGesture() {
+function isSwipeGesture() {
     const diff = touchEndX - touchStartX;
-    if (Math.abs(diff) < SWIPE_THRESHOLD) return;
-    if (diff > 0) {
-        handleShapeClick('Square');
-    } else {
-        handleShapeClick('Star');
-    }
+    return Math.abs(diff) >= SWIPE_THRESHOLD;
 }
 
 document.addEventListener('keydown', (e) => {
@@ -339,20 +334,11 @@ gameContainer.addEventListener('touchstart', (e) => {
 
 gameContainer.addEventListener('touchend', (e) => {
     touchEndX = e.changedTouches[0].screenX;
-    handleSwipeGesture();
-}, false);
-
-// -- Mobile tap left/right support --
-gameContainer.addEventListener('touchend', (e) => {
-    // Use existing swipe if swipe distance is sufficient
-    touchEndX = e.changedTouches[0].screenX;
-    const diff = touchEndX - touchStartX;
-    if (Math.abs(diff) >= SWIPE_THRESHOLD) {
-        handleSwipeGesture();
-        return;
+    if (isSwipeGesture()) {
+        return; // ignore swipes
     }
 
-    // If it's just a tap, determine which side of the screen was touched
+    // It's a tap: determine which side of the screen was touched
     const screenWidth = window.innerWidth;
     const touchX = e.changedTouches[0].clientX;
 
@@ -363,5 +349,5 @@ gameContainer.addEventListener('touchend', (e) => {
     } else {
         handleShapeClick('Square'); // right side = Square
     }
-});
+}, false);
 

--- a/styles.css
+++ b/styles.css
@@ -120,6 +120,16 @@ button:hover {
   padding-left: 0;
 }
 
+#round-counter {
+  position: absolute;
+  top: 10px;
+  left: 0;
+  right: 0;
+  margin: 0;
+  text-align: center;
+  font-weight: bold;
+}
+
 #game-container,
 #calibrate-container,
 #tutorial-container {
@@ -133,6 +143,7 @@ button:hover {
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
+  position: relative;
 }
 
 #tutorial-container {


### PR DESCRIPTION
## Summary
- ensure game container is relative-positioned and place round counter at the top center
- distinguish between swipes and taps on touch devices

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6882c16e348883208770b89e44452220