### PR TITLE
fix: ensure start and calibrate buttons show on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     </button>
     <button id="calibrate-button" class="primary-button">Calibrate</button>
 
-    <section id="calibrate-container-parent" >
+    <section id="calibrate-container-parent" class="hidden">
     <section id="calibrate-container" class="card">
   <div class="calibrate-content">
     <img id="calibrateShape-image" alt="Shape Image" />
@@ -66,6 +66,5 @@
   </main>
 
   <script type="module" src="main.js"></script>
-  <script type="module" src="CalibrateManager.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- prevent calibration overlay from showing before scripts run
- load calibration logic once via main module

## Testing
- `node --check main.js && echo "main ok"`
- `node --check CalibrateManager.js && echo "calibrate ok"`


------
https://chatgpt.com/codex/tasks/task_b_688aa69a0140832097171206e12f3fc0