### PR TITLE
fix: ensure buttons visible on mobile Chrome

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5,12 +5,11 @@ body {
 }
 
 html, body {
-  height: 100%;
+  min-height: 100vh;
 }
 
 .wrapper {
   background: #f0f4f8;
-  height: 100%;
   max-width: 100vw;
   margin: 0;
   padding: 0;
@@ -19,6 +18,7 @@ html, body {
   align-items: center;
   justify-content: flex-start; /* Align content to top */
   position: relative;
+  min-height: 100vh;
 }
 
 
@@ -30,7 +30,14 @@ html, body {
   margin: 0;
   text-align: center;
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
+}
+
+@supports (height: 100dvh) {
+  html, body, .wrapper, .card,
+  #game-container, #calibrate-container, #tutorial-container {
+    min-height: 100dvh;
+  }
 }
 
 .hidden {
@@ -135,7 +142,7 @@ button:hover {
 #tutorial-container {
   background: #f0f4f8;
   width: 100vw;
-  height: 100vh;
+  min-height: 100vh;
   box-sizing: border-box;
 
   /* Flexbox for vertical & horizontal centering */


### PR DESCRIPTION
## Summary
- ensure start game and calibrate buttons are visible on mobile Chrome by using dynamic viewport height units

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688ab377b9c48320bd202e8e9283d695