### PR TITLE
Fix mobile Chrome start button rendering issue

### DIFF
--- a/main.js
+++ b/main.js
@@ -106,17 +106,21 @@ if (enterFullscreenBtn) {
 // Initialize button visibility on load
 updateFullscreenButtonVisibility();
 
+function forceWrapperRedraw() {
+    const wrapper = document.querySelector('.wrapper');
+    if (wrapper instanceof HTMLElement) {
+        wrapper.style.display = 'none';
+        void wrapper.offsetHeight;
+        wrapper.style.display = '';
+        console.debug('Forced redraw');
+    } else {
+        console.debug('Wrapper not found');
+    }
+}
+
+// Delay even further to ensure layout is complete
 if (isMobile()) {
-    // Mobile Chrome sometimes fails to render initial buttons.
-    // Briefly hide and show the main wrapper to force a redraw.
-    setTimeout(() => {
-        const wrapper = document.querySelector('.wrapper');
-        if (wrapper) {
-            wrapper.style.display = 'none';
-            void wrapper.offsetHeight; // force reflow
-            wrapper.style.display = '';
-        }
-    }, 100);
+    setTimeout(forceWrapperRedraw, 300);
 }
 
 

--- a/main.js
+++ b/main.js
@@ -106,6 +106,19 @@ if (enterFullscreenBtn) {
 // Initialize button visibility on load
 updateFullscreenButtonVisibility();
 
+if (isMobile()) {
+    // Mobile Chrome sometimes fails to render initial buttons.
+    // Briefly hide and show the main wrapper to force a redraw.
+    setTimeout(() => {
+        const wrapper = document.querySelector('.wrapper');
+        if (wrapper) {
+            wrapper.style.display = 'none';
+            void wrapper.offsetHeight; // force reflow
+            wrapper.style.display = '';
+        }
+    }, 100);
+}
+
 
 function setElementActive(container, active) {
     var value = active == true ? 'block' : 'none';


### PR DESCRIPTION
## Summary
- force a short mobile-only redraw to ensure start and calibrate buttons appear

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688abac1ecac83209059c669b7636cd3